### PR TITLE
chore: add deploy configuration

### DIFF
--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -16,6 +16,17 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      
+      - name: Install Jekyll
+        run: gem install jekyll
+      
+      - name: Install python dependencies
+        run: pip install bibble
     
       - name: Build
         id: build

--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+    
+      - name: Build
+        id: build
+        run: make
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: success()
+        with:
+          allow_empty_commit: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: _site
+          publish_dir: ./
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Inspiration: https://github.com/algomaster99/algomaster99.github.io/commit/864c0d86be7746898fe548e85daf4dabeb801cae

The workflow will ensure that the site is deployed on `publish` branch. It is a cool workflow because the build files and source files stay in different branches. See example here - https://github.com/algomaster99/algomaster99.github.io/tree/publish